### PR TITLE
use legacy URL for Node 8 compatibility

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,21 @@
+## 0.1.2 (Dec 4, 2018)
+
+#### :bug: Bug Fix
+
+- [#3](https://github.com/guestlinelabs/peek-a-vault/pull/3) Use legacy URL for Node 8 compatibility, as the global URL would break,
+
+## 0.1.1 (Nov 29, 2018)
+
+#### :house: Internal
+
+- [#2](https://github.com/guestlinelabs/peek-a-vault/pull/2) Add invalid uri on the error message when validation fails.
+
+## 0.1.0 (Nov 27, 2018)
+
+#### :nail_care: Enhancement
+
+- [#1](https://github.com/guestlinelabs/peek-a-vault/pull/1) Added an option on the client creation to cache all the secrets that are retreived, and also an optional parameter on the function to retrieve secrets to override this behaviour on an individual level.
+
+## 0.0.1 (Nov 26, 2018)
+
+First version!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guestlinelabs/peek-a-vault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1884,14 +1884,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1906,20 +1904,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2036,8 +2031,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2049,7 +2043,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2064,7 +2057,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2072,14 +2064,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2098,7 +2088,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2179,8 +2168,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2192,7 +2180,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2314,7 +2301,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5011,9 +4997,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
-      "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
       "dev": true
     },
     "pretty-ms": {
@@ -6060,9 +6046,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guestlinelabs/peek-a-vault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Client handler for getting secrets from Key Vault with a local fallback",
   "main": "dist/index.js",
   "scripts": {
@@ -40,7 +40,7 @@
   "devDependencies": {
     "ava": "1.0.0-rc.2",
     "nyc": "13.1.0",
-    "prettier": "1.15.2",
+    "prettier": "1.15.3",
     "rimraf": "2.6.2",
     "source-map-support": "0.5.9",
     "ts-node": "7.0.1",
@@ -48,7 +48,7 @@
     "tslint-config-prettier": "1.17.0",
     "tslint-plugin-ava": "0.1.2",
     "tslint-plugin-prettier": "2.0.1",
-    "typescript": "3.1.6"
+    "typescript": "3.2.1"
   },
   "dependencies": {
     "azure-keyvault": "3.0.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { KeyVaultClient } from 'azure-keyvault';
 import msRestAzure, { MSIAppServiceTokenCredentials } from 'ms-rest-azure';
+import { URL } from 'url';
 
 type SecretValue = string;
 type GetSecret<T extends string, S extends string> = (


### PR DESCRIPTION
So I forgot that [URL](https://nodejs.org/api/url.html#url_class_url) was only globally available since v10...

I didn't catch it because I didn't run it on Node 8. The new Azure Pipelines runs on node 8, so if it passes means that its ok now (actually the previous build failed)

Also added CHANGELOG, because why not